### PR TITLE
Initialize bonuses object for players before rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,6 +127,16 @@ function renderAllRounds() {
     body.appendChild(headerRow);
     
     round.players.forEach((playerData, playerIndex) => {
+      // Ensure bonuses object exists with default values for each player
+      playerData.bonuses = {
+        mermaid: 0,
+        pirate: 0,
+        skullking: 0,
+        nonTrump14: 0,
+        trump14: 0,
+        ...playerData.bonuses
+      };
+
       const row = document.createElement("div");
       row.className = "score-row";
     


### PR DESCRIPTION
## Summary
- Avoid undefined bonus data when adding new players by assigning default bonus counters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897615c59e8832b96d9502bee501de1