### PR TITLE
Fix bid/actual input alignment in scoreboard

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@
 .score-row input {
   width: 100%;
   text-align: center;
+  box-sizing: border-box;
 }
 
 .score-header {
@@ -82,7 +83,7 @@ h1 {
   display: block;
 }
 
-.player-row, .score-row {
+.player-row {
   display: flex;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
@@ -93,6 +94,7 @@ input[type="text"], input[type="number"] {
   flex: 1;
   padding: 0.3rem;
   font-size: 1rem;
+  box-sizing: border-box;
 }
 
 button {
@@ -105,12 +107,3 @@ button {
   margin-top: 0.5rem;
 }
 
-.score-row {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
-  align-items: center;
-  gap: 0.5rem;
-}
-.score-row input {
-  width: 100%;
-}


### PR DESCRIPTION
## Summary
- Ensure bid/actual number inputs stay within their grid columns by using border-box sizing
- Remove flex layout from score rows and apply border-box to inputs for consistent sizing

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/skull-king/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689765ef0190832b9c635c0102a27b68