### PR TITLE
Center player removal buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -90,6 +90,10 @@ h1 {
   align-items: center;
 }
 
+.player-row button {
+  margin-top: 0;
+}
+
 input[type="text"], input[type="number"] {
   flex: 1;
   padding: 0.3rem;


### PR DESCRIPTION
## Summary
- Reset margin for player editor buttons so remove control aligns with player name field

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976ac4978c832bb721a4fa3300e638