### PR TITLE
Align round headers and enlarge checkboxes

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,9 +81,13 @@ function renderAllRounds() {
     header.className = "accordion-header";
     header.dataset.roundIndex = roundIndex;
 
+    const title = document.createElement("span");
+    title.textContent = `Round ${roundIndex + 1}`;
+    title.className = "round-title";
+
     const ignoreWrapper = document.createElement("span");
     ignoreWrapper.className = "ignore-checkbox";
-    
+
     const checkbox = document.createElement("input");
     checkbox.type = "checkbox";
     checkbox.checked = !round.ignored;
@@ -91,12 +95,9 @@ function renderAllRounds() {
       round.ignored = !checkbox.checked;
       updateCumulativeScores();
     };
-    
-    const title = document.createElement("span");
-    title.textContent = `Round ${roundIndex + 1}`;
 
     ignoreWrapper.appendChild(checkbox);
-    header.append(ignoreWrapper, title);
+    header.append(title, ignoreWrapper);
 
     header.onclick = (e) => {
       // Prevent toggle if clicking on the checkbox or its label/area

--- a/style.css
+++ b/style.css
@@ -72,6 +72,22 @@ h1 {
   background: #ddd;
   font-weight: bold;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.accordion-header .round-title {
+  display: inline-block;
+  width: 6rem;
+}
+
+.accordion-header .ignore-checkbox {
+  margin-left: 1rem;
+}
+
+.accordion-header .ignore-checkbox input {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .accordion-body {


### PR DESCRIPTION
## Summary
- move round ignore checkboxes to the right of the round title
- enlarge and align checkboxes for easier selection

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897700984a0832b82349de12e7eab0a