### PR TITLE
Add bid modifier and bet bonuses with overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,6 +16,28 @@
   cursor: pointer;
 }
 
+.more-bonuses {
+  position: relative;
+}
+
+.bonus-overlay {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  gap: 0.5rem;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.bonus-overlay.open {
+  display: flex;
+}
+
 .bonus-counter .label {
   font-size: 1.25rem;
 }


### PR DESCRIPTION
## Summary
- Extend player bonuses with bid modifier and bet options.
- Add "..." menu overlay to access new bonuses per player.
- Update scoring logic to account for bid modifiers and bets.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/skull-king/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6897af03c6e4832b8669d5ac05f737f3