### PR TITLE
Improve bonus styling and mobile number controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,8 +124,8 @@ function renderAllRounds() {
 
     const headerRow = document.createElement("div");
     headerRow.className = "score-row score-header";
-    
-    ["Player", "Bid", "Actual", "Score", "Cumulative"].forEach(text => {
+
+    ["Player", "Bid", "Take", "Score", "Cumulative"].forEach(text => {
       const span = document.createElement("span");
       span.textContent = text;
       headerRow.appendChild(span);
@@ -155,6 +155,7 @@ function renderAllRounds() {
       const bidInput = document.createElement("input");
       bidInput.type = "number";
       bidInput.value = playerData.bid;
+      bidInput.readOnly = true;
       bidInput.oninput = () => {
         playerData.bid = parseInt(bidInput.value || "0");
         renderAllRounds(); // to recalc scores
@@ -164,6 +165,7 @@ function renderAllRounds() {
       const actualInput = document.createElement("input");
       actualInput.type = "number";
       actualInput.value = playerData.actual;
+      actualInput.readOnly = true;
       actualInput.oninput = () => {
         playerData.actual = parseInt(actualInput.value || "0");
         renderAllRounds();
@@ -183,7 +185,7 @@ function renderAllRounds() {
 
       const bonusRow = document.createElement("div");
       bonusRow.className = "bonus-row";
-      
+
       // Bonus buttons config
       const bonuses = [
         { key: "mermaid", label: "🧜", max: 2 },
@@ -194,6 +196,9 @@ function renderAllRounds() {
         { key: "bidModifier", label: "±", values: [-1, 0, 1] },
         { key: "bet", label: "💰", values: [0, 10, 20] }
       ];
+
+      const modifiedBid = playerData.bid + (playerData.bonuses.bidModifier || 0);
+      const madeBid = playerData.actual === modifiedBid;
 
       bonuses.forEach(({ key, label, max, values }) => {
         const container = document.createElement("div");
@@ -210,6 +215,12 @@ function renderAllRounds() {
           count.textContent = current === 0 ? "" : (current > 0 ? `+${current}` : current);
         } else {
           count.textContent = current === 0 ? "" : current;
+        }
+
+        if (current !== 0) {
+          const affectsScore =
+            key === "bidModifier" || key === "bet" ? true : madeBid;
+          container.classList.add(affectsScore ? "bonus-active" : "bonus-ignored");
         }
 
         container.onclick = () => {

--- a/style.css
+++ b/style.css
@@ -1,21 +1,28 @@
 .bonus-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 0.5rem 0 1rem;
+  gap: 0.25rem;
+  margin: 0.25rem 0;
   justify-content: flex-start;
 }
 
 .bonus-counter {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.15rem;
   background: #f0f0f0;
-  padding: 0.25rem 0.5rem;
-  border-radius: 6px;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
   cursor: pointer;
 }
 
+.bonus-counter.bonus-active {
+  background: #d6ecff;
+}
+
+.bonus-counter.bonus-ignored {
+  background: #ffe5e5;
+}
 
 .bonus-counter .label {
   font-size: 1.25rem;
@@ -41,11 +48,24 @@
   box-sizing: border-box;
 }
 
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  opacity: 1;
+}
+
 .score-header {
   font-weight: bold;
   background: #f0f0f0;
   padding: 0.25rem;
   border-radius: 4px;
+}
+
+.score-header span {
+  width: 100%;
+}
+
+.score-header span:not(:first-child) {
+  text-align: center;
 }
 
 .round-nav {


### PR DESCRIPTION
## Summary
- highlight active bonuses in blue when they affect score and red when ignored
- compact bonus button styling and centered table headers
- always show number spinners, make bid/take fields read-only, rename Take column

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689809ef02c8832b8065e40f34066370