### PR TITLE
style: refine bid/take column layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,6 +136,8 @@ function renderAllRounds() {
     ["Player", "Bid", "Take", "Score", "Cumulative"].forEach(text => {
       const span = document.createElement("span");
       span.textContent = text;
+      if (text === "Bid") span.classList.add("bid");
+      if (text === "Take") span.classList.add("take");
       headerRow.appendChild(span);
     });
     
@@ -162,6 +164,7 @@ function renderAllRounds() {
     
       const bidInput = document.createElement("input");
       bidInput.type = "number";
+      bidInput.className = "bid-input";
       bidInput.value = playerData.bid;
       allowSpinnerOnly(bidInput);
       bidInput.oninput = () => {
@@ -172,6 +175,7 @@ function renderAllRounds() {
     
       const actualInput = document.createElement("input");
       actualInput.type = "number";
+      actualInput.className = "take-input";
       actualInput.value = playerData.actual;
       allowSpinnerOnly(actualInput);
       actualInput.oninput = () => {

--- a/style.css
+++ b/style.css
@@ -48,6 +48,14 @@
   box-sizing: border-box;
 }
 
+.score-row .bid-input,
+.score-row .take-input {
+  width: 3rem;
+  text-align: left;
+  outline: none;
+  justify-self: start;
+}
+
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
   opacity: 1;
@@ -66,6 +74,11 @@ input[type="number"]::-webkit-outer-spin-button {
 
 .score-header span:not(:first-child) {
   text-align: center;
+}
+
+.score-header span.bid,
+.score-header span.take {
+  text-align: left;
 }
 
 .round-nav {


### PR DESCRIPTION
## Summary
- left align Bid and Take headers
- size bid/take inputs and remove outline

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898115ba7d8832ba2863b59057eeda1