### PR TITLE
Align scoreboard columns with headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -130,6 +130,9 @@ function renderAllRounds() {
     body.className = "accordion-body";
     if (!round.ignored && uiState.expandedRounds.has(roundIndex)) body.classList.add("open");
 
+    const grid = document.createElement("div");
+    grid.className = "score-grid";
+
     const headerRow = document.createElement("div");
     headerRow.className = "score-row score-header";
 
@@ -138,11 +141,14 @@ function renderAllRounds() {
       span.textContent = text;
       if (text === "Bid") span.classList.add("bid");
       if (text === "Take") span.classList.add("take");
+      if (text === "Score") span.classList.add("score");
+      if (text === "Cumulative") span.classList.add("cumulative");
       headerRow.appendChild(span);
     });
-    
-    body.appendChild(headerRow);
-    
+
+    grid.appendChild(headerRow);
+    body.appendChild(grid);
+
     round.players.forEach((playerData, playerIndex) => {
       // Ensure bonuses object exists with default values for each player
       playerData.bonuses = {
@@ -193,7 +199,7 @@ function renderAllRounds() {
       cumulativeSpan.textContent = cumulative;
     
       row.append(name, bidInput, actualInput, scoreSpan, cumulativeSpan);
-      body.appendChild(row);
+      grid.appendChild(row);
 
       const bonusRow = document.createElement("div");
       bonusRow.className = "bonus-row";
@@ -251,7 +257,7 @@ function renderAllRounds() {
         bonusRow.appendChild(container);
       });
 
-      body.appendChild(bonusRow);
+      grid.appendChild(bonusRow);
     });
 
     // Navigation buttons to jump between non-ignored rounds

--- a/style.css
+++ b/style.css
@@ -1,9 +1,19 @@
+/* Grid container for the scoreboard */
+.score-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
+  align-items: center;
+  gap: 0.25rem 0.5rem;
+  padding-left: 0.25rem;
+}
+
 .bonus-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
   margin: 0.25rem 0;
   justify-content: flex-start;
+  grid-column: 1 / -1;
 }
 
 .bonus-counter {
@@ -34,12 +44,7 @@
 }
 
 .score-row {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
-  align-items: center;
-  gap: 0.5rem;
-  margin: 0.25rem 0;
-  padding-left: 0.25rem;
+  display: contents;
 }
 
 .score-row input {
@@ -50,7 +55,6 @@
 
 .score-row .bid-input,
 .score-row .take-input {
-  width: 3rem;
   text-align: left;
   outline: none;
   justify-self: start;
@@ -61,14 +65,11 @@ input[type="number"]::-webkit-outer-spin-button {
   opacity: 1;
 }
 
-.score-header {
+.score-header span {
   font-weight: bold;
   background: #f0f0f0;
   padding: 0.25rem;
   border-radius: 4px;
-}
-
-.score-header span {
   width: 100%;
 }
 
@@ -77,7 +78,9 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 .score-header span.bid,
-.score-header span.take {
+.score-header span.take,
+.score-header span.score,
+.score-header span.cumulative {
   text-align: left;
 }
 


### PR DESCRIPTION
## Summary
- Render score rows within a shared CSS grid so player columns match header sizing
- Span bonus rows across all grid columns
- Left-align the Score and Cumulative column headers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689814272504832bafa8370a94100183