### PR TITLE
Replace number inputs with custom spinners and fix header alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,12 +25,55 @@ function createPlayer() {
   };
 }
 
-function allowSpinnerOnly(input) {
+function createSpinnerInput(initialValue, onChange, className, disabled) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "spinner-input";
+
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = className;
+  input.value = initialValue;
+  input.disabled = disabled;
+
+  const controls = document.createElement("div");
+  controls.className = "spinner-controls";
+
+  const up = document.createElement("button");
+  up.textContent = "▲";
+  up.disabled = disabled;
+  up.onclick = () => {
+    const current = parseInt(input.value || "0", 10);
+    const val = current + 1;
+    input.value = val;
+    onChange(val);
+  };
+
+  const down = document.createElement("button");
+  down.textContent = "▼";
+  down.disabled = disabled;
+  down.onclick = () => {
+    const current = parseInt(input.value || "0", 10);
+    const val = current - 1;
+    input.value = val;
+    onChange(val);
+  };
+
+  controls.append(up, down);
+  wrapper.append(input, controls);
+
   input.addEventListener("keydown", e => {
-    if (["ArrowUp", "ArrowDown", "Tab"].includes(e.key)) return;
-    e.preventDefault();
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      up.onclick();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      down.onclick();
+    } else if (e.key !== "Tab") {
+      e.preventDefault();
+    }
   });
-  input.addEventListener("paste", e => e.preventDefault());
+
+  return wrapper;
 }
 
 function renderPlayerEditor() {
@@ -168,27 +211,25 @@ function renderAllRounds() {
       const name = document.createElement("span");
       name.textContent = gameState.players[playerIndex];
     
-      const bidInput = document.createElement("input");
-      bidInput.type = "number";
-      bidInput.className = "bid-input";
-      bidInput.value = playerData.bid;
-      allowSpinnerOnly(bidInput);
-      bidInput.oninput = () => {
-        playerData.bid = parseInt(bidInput.value || "0");
-        renderAllRounds(); // to recalc scores
-      };
-      bidInput.disabled = round.ignored;
-    
-      const actualInput = document.createElement("input");
-      actualInput.type = "number";
-      actualInput.className = "take-input";
-      actualInput.value = playerData.actual;
-      allowSpinnerOnly(actualInput);
-      actualInput.oninput = () => {
-        playerData.actual = parseInt(actualInput.value || "0");
-        renderAllRounds();
-      };
-      actualInput.disabled = round.ignored;
+      const bidInput = createSpinnerInput(
+        playerData.bid,
+        val => {
+          playerData.bid = val;
+          renderAllRounds(); // to recalc scores
+        },
+        "bid-input",
+        round.ignored
+      );
+
+      const actualInput = createSpinnerInput(
+        playerData.actual,
+        val => {
+          playerData.actual = val;
+          renderAllRounds();
+        },
+        "take-input",
+        round.ignored
+      );
     
       const scoreSpan = document.createElement("span");
       const score = computeScore(playerData, roundIndex);

--- a/style.css
+++ b/style.css
@@ -60,15 +60,39 @@
   justify-self: start;
 }
 
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  opacity: 1;
+/* Custom spinner wrapper and controls */
+.spinner-input {
+  display: flex;
+  width: 100%;
+  align-items: center;
+}
+
+.spinner-controls {
+  display: flex;
+  flex-direction: column;
+  margin-left: 0.25rem;
+}
+
+.spinner-controls button {
+  padding: 0;
+  margin: 0;
+  width: 1rem;
+  height: 0.9rem;
+  line-height: 0.9rem;
+  background: #ddd;
+  border: 1px solid #999;
+  cursor: pointer;
+  color: #000;
+}
+
+.spinner-controls button + button {
+  border-top: none;
 }
 
 .score-header span {
   font-weight: bold;
   background: #f0f0f0;
-  padding: 0.25rem;
+  padding: 0.25rem 0;
   border-radius: 4px;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- Align score header columns with data rows by removing extra header padding
- Replace native number inputs with text fields wrapped in custom spinner controls

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68981b434f78832b84a27ad4dfcb6860