### PR TITLE
Remove grid gaps and convert bid/take inputs to text

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,11 +29,9 @@ function createSpinnerInput(initialValue, onChange, className, disabled) {
   const wrapper = document.createElement("div");
   wrapper.className = "spinner-input";
 
-  const input = document.createElement("input");
-  input.type = "text";
-  input.className = className;
-  input.value = initialValue;
-  input.disabled = disabled;
+  const value = document.createElement("span");
+  value.className = `${className} spinner-value`;
+  value.textContent = initialValue;
 
   const controls = document.createElement("div");
   controls.className = "spinner-controls";
@@ -42,9 +40,9 @@ function createSpinnerInput(initialValue, onChange, className, disabled) {
   up.textContent = "▲";
   up.disabled = disabled;
   up.onclick = () => {
-    const current = parseInt(input.value || "0", 10);
+    const current = parseInt(value.textContent || "0", 10);
     const val = current + 1;
-    input.value = val;
+    value.textContent = val;
     onChange(val);
   };
 
@@ -52,26 +50,14 @@ function createSpinnerInput(initialValue, onChange, className, disabled) {
   down.textContent = "▼";
   down.disabled = disabled;
   down.onclick = () => {
-    const current = parseInt(input.value || "0", 10);
+    const current = parseInt(value.textContent || "0", 10);
     const val = current - 1;
-    input.value = val;
+    value.textContent = val;
     onChange(val);
   };
 
   controls.append(up, down);
-  wrapper.append(input, controls);
-
-  input.addEventListener("keydown", e => {
-    if (e.key === "ArrowUp") {
-      e.preventDefault();
-      up.onclick();
-    } else if (e.key === "ArrowDown") {
-      e.preventDefault();
-      down.onclick();
-    } else if (e.key !== "Tab") {
-      e.preventDefault();
-    }
-  });
+  wrapper.append(value, controls);
 
   return wrapper;
 }

--- a/style.css
+++ b/style.css
@@ -3,8 +3,7 @@
   display: grid;
   grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
   align-items: center;
-  gap: 0.25rem 0.5rem;
-  padding-left: 0.25rem;
+  gap: 0;
 }
 
 .bonus-row {
@@ -47,8 +46,12 @@
   display: contents;
 }
 
-.score-row input {
-  width: 100%;
+.score-row > :first-child {
+  padding-left: 12px;
+}
+
+.spinner-value {
+  flex: 1;
   text-align: center;
   box-sizing: border-box;
 }
@@ -56,8 +59,6 @@
 .score-row .bid-input,
 .score-row .take-input {
   text-align: left;
-  outline: none;
-  justify-self: start;
 }
 
 /* Custom spinner wrapper and controls */


### PR DESCRIPTION
## Summary
- Drop grid gaps from score rows and apply 12px left padding to the first column
- Replace bid/take inputs with text values while keeping arrow controls

## Testing
- `node --check app.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68981e4fbdf4832ba51a7db7ff379847