### PR TITLE
Align spinner controls left in score cells

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,8 +51,7 @@
 }
 
 .spinner-value {
-  flex: 1;
-  text-align: center;
+  text-align: left;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- Left-align numeric value in custom spinner so up/down controls sit immediately after the number

## Testing
- `npm test` (fails: ENOENT no package.json)

------
https://chatgpt.com/codex/tasks/task_e_68982068ffbc832b936effb6e491dc3d