### PR TITLE
Use Total column and space player rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -165,13 +165,13 @@ function renderAllRounds() {
     const headerRow = document.createElement("div");
     headerRow.className = "score-row score-header";
 
-    ["Player", "Bid", "Take", "Score", "Cumulative"].forEach(text => {
+    ["Player", "Bid", "Take", "Score", "Total"].forEach(text => {
       const span = document.createElement("span");
       span.textContent = text;
       if (text === "Bid") span.classList.add("bid");
       if (text === "Take") span.classList.add("take");
       if (text === "Score") span.classList.add("score");
-      if (text === "Cumulative") span.classList.add("cumulative");
+      if (text === "Total") span.classList.add("cumulative");
       headerRow.appendChild(span);
     });
 

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
-  margin: 0.25rem 0;
+  margin: 0.25rem 0 0;
   justify-content: flex-start;
   grid-column: 1 / -1;
 }
@@ -44,6 +44,10 @@
 
 .score-row {
   display: contents;
+}
+
+.score-row:not(.score-header) > * {
+  margin-top: 0.25rem;
 }
 
 .score-row > :first-child {


### PR DESCRIPTION
## Summary
- Rename the score table's "Cumulative" column to "Total" for clarity
- Add top margins to player rows and adjust bonus row spacing to separate players

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689822fe4b14832b936ac52f30f36065