### PR TITLE
Use +/- buttons and add player row spacing

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,27 +36,27 @@ function createSpinnerInput(initialValue, onChange, className, disabled) {
   const controls = document.createElement("div");
   controls.className = "spinner-controls";
 
-  const up = document.createElement("button");
-  up.textContent = "▲";
-  up.disabled = disabled;
-  up.onclick = () => {
-    const current = parseInt(value.textContent || "0", 10);
-    const val = current + 1;
-    value.textContent = val;
-    onChange(val);
-  };
-
-  const down = document.createElement("button");
-  down.textContent = "▼";
-  down.disabled = disabled;
-  down.onclick = () => {
+  const minus = document.createElement("button");
+  minus.textContent = "−";
+  minus.disabled = disabled;
+  minus.onclick = () => {
     const current = parseInt(value.textContent || "0", 10);
     const val = current - 1;
     value.textContent = val;
     onChange(val);
   };
 
-  controls.append(up, down);
+  const plus = document.createElement("button");
+  plus.textContent = "+";
+  plus.disabled = disabled;
+  plus.onclick = () => {
+    const current = parseInt(value.textContent || "0", 10);
+    const val = current + 1;
+    value.textContent = val;
+    onChange(val);
+  };
+
+  controls.append(minus, plus);
   wrapper.append(value, controls);
 
   return wrapper;

--- a/style.css
+++ b/style.css
@@ -47,7 +47,7 @@
 }
 
 .score-row:not(.score-header) > * {
-  margin-top: 0.25rem;
+  margin-top: 0.5rem;
 }
 
 .score-row > :first-child {
@@ -73,7 +73,7 @@
 
 .spinner-controls {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   margin-left: 0.25rem;
 }
 
@@ -81,8 +81,8 @@
   padding: 0;
   margin: 0;
   width: 1rem;
-  height: 0.9rem;
-  line-height: 0.9rem;
+  height: 1rem;
+  line-height: 1rem;
   background: #ddd;
   border: 1px solid #999;
   cursor: pointer;
@@ -90,7 +90,7 @@
 }
 
 .spinner-controls button + button {
-  border-top: none;
+  border-left: none;
 }
 
 .score-header span {


### PR DESCRIPTION
## Summary
- Replace spinner arrow controls with horizontal minus and plus buttons
- Add extra space above each player's score row for clarity

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_689824cd1890832ba11cd6c84706ee51