### PR TITLE
Prevent negative values in spinners and increase player row spacing

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,11 +39,20 @@ function createSpinnerInput(initialValue, onChange, className, disabled) {
   const minus = document.createElement("button");
   minus.textContent = "−";
   minus.disabled = disabled;
+
+  const updateDisabled = () => {
+    if (!disabled) {
+      minus.disabled = parseInt(value.textContent || "0", 10) <= 0;
+    }
+  };
+
   minus.onclick = () => {
     const current = parseInt(value.textContent || "0", 10);
+    if (current <= 0) return;
     const val = current - 1;
     value.textContent = val;
     onChange(val);
+    updateDisabled();
   };
 
   const plus = document.createElement("button");
@@ -54,10 +63,13 @@ function createSpinnerInput(initialValue, onChange, className, disabled) {
     const val = current + 1;
     value.textContent = val;
     onChange(val);
+    updateDisabled();
   };
 
   controls.append(minus, plus);
   wrapper.append(value, controls);
+
+  updateDisabled();
 
   return wrapper;
 }

--- a/style.css
+++ b/style.css
@@ -47,7 +47,7 @@
 }
 
 .score-row:not(.score-header) > * {
-  margin-top: 0.75rem;
+  margin-top: 1.125rem;
 }
 
 .score-row > :first-child {


### PR DESCRIPTION
## Summary
- increase spacing above player rows for clearer separation
- prevent bid/take spinners from going below zero

## Testing
- `npm test` (fails: ENOENT package.json)
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6898972e494c832ba3295d98804e156b