### PR TITLE
Add loot bonus feature and evenly space bonus buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@
   flex-wrap: wrap;
   gap: 0.25rem;
   margin: 0.25rem 0 0;
-  justify-content: flex-start;
+  justify-content: space-evenly;
   grid-column: 1 / -1;
 }
 
@@ -40,6 +40,24 @@
 .bonus-counter.disabled {
   pointer-events: none;
   opacity: 0.5;
+}
+
+.loot-dropdown {
+  position: fixed;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 0.25rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+
+.loot-dropdown div {
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.loot-dropdown div:hover {
+  background: #eee;
 }
 
 .score-row {


### PR DESCRIPTION
## Summary
- Evenly space bonus buttons across rows
- Introduce loot partnerships via treasure chest button
- Score loot bonuses when both partners hit their bids

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68989d64a984832b99ea648f955f82ec