### PR TITLE
Sanitize loot partnerships when players removed

### DIFF
--- a/app.js
+++ b/app.js
@@ -520,9 +520,15 @@ function computeScore(player, roundIndex) {
   else
     base = made ? 20 * bid : -10 * Math.abs(actual - modifiedBid);
   let loot = 0;
-  (bonuses?.loot || []).forEach(partnerIndex => {
-    const partner = gameState.rounds[roundIndex].players[partnerIndex];
-    if (!partner) return; // skip if partner no longer exists
+  // Filter out any loot partnerships that reference players that no longer exist
+  const roundPlayers = gameState.rounds[roundIndex]?.players || [];
+  const validLootPartners = (bonuses?.loot || []).filter(
+    idx => roundPlayers[idx]
+  );
+  // Persist the cleaned list back to the player to avoid repeated checks
+  if (bonuses && bonuses.loot) bonuses.loot = validLootPartners;
+  validLootPartners.forEach(partnerIndex => {
+    const partner = roundPlayers[partnerIndex];
     const partnerMod = partner.bid + (partner.bonuses?.bidModifier ?? 0);
     const partnerMade = partner.actual === partnerMod;
     if (made && partnerMade) loot += 20;


### PR DESCRIPTION
## Summary
- prevent crashes when loot partnerships reference removed players
- clean invalid loot entries during score calculation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` manual scenario simulating player removal and leftover loot indices

------
https://chatgpt.com/codex/tasks/task_e_68990fbd8814832bbeacb66cd024c04f