### PR TITLE
Fix loot partnership dropdown positioning and toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,8 @@ const gameState = {
 
 const uiState = {
   expandedRounds: new Set([-1]), // -1 for player editor
-  lootDropdown: null
+  lootDropdown: null,
+  lootDropdownButton: null,
 };
 
 function createPlayer() {
@@ -453,8 +454,15 @@ function addRound() {
 
 function showLootDropdown(button, roundIndex, playerIndex) {
   if (uiState.lootDropdown) {
+    if (uiState.lootDropdownButton === button) {
+      uiState.lootDropdown.remove();
+      uiState.lootDropdown = null;
+      uiState.lootDropdownButton = null;
+      return;
+    }
     uiState.lootDropdown.remove();
     uiState.lootDropdown = null;
+    uiState.lootDropdownButton = null;
   }
   const dropdown = document.createElement("div");
   dropdown.className = "loot-dropdown";
@@ -467,14 +475,16 @@ function showLootDropdown(button, roundIndex, playerIndex) {
       addLootPartnership(roundIndex, playerIndex, idx);
       dropdown.remove();
       uiState.lootDropdown = null;
+      uiState.lootDropdownButton = null;
     };
     dropdown.appendChild(option);
   });
   document.body.appendChild(dropdown);
   const rect = button.getBoundingClientRect();
-  dropdown.style.top = `${rect.bottom}px`;
-  dropdown.style.right = `${window.innerWidth - rect.right}px`;
+  dropdown.style.top = `${rect.bottom + window.scrollY}px`;
+  dropdown.style.left = `${rect.left + window.scrollX}px`;
   uiState.lootDropdown = dropdown;
+  uiState.lootDropdownButton = button;
 }
 
 function addLootPartnership(roundIndex, p1, p2) {
@@ -505,6 +515,7 @@ document.addEventListener("click", (e) => {
   ) {
     uiState.lootDropdown.remove();
     uiState.lootDropdown = null;
+    uiState.lootDropdownButton = null;
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -43,7 +43,7 @@
 }
 
 .loot-dropdown {
-  position: fixed;
+  position: absolute;
   background: #fff;
   border: 1px solid #ccc;
   border-radius: 0.25rem;


### PR DESCRIPTION
## Summary
- Ensure loot partnership dropdown moves with its icon by anchoring position to scroll offsets
- Allow loot icon to toggle dropdown open and closed

## Testing
- `node --check app.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689912657e4c832ba9a4aaa911dd6b69