### PR TITLE
Align loot pairings left

### DIFF
--- a/app.js
+++ b/app.js
@@ -334,7 +334,7 @@ function renderAllRounds() {
       });
 
       const lootRow = document.createElement("div");
-      lootRow.className = "bonus-row";
+      lootRow.className = "bonus-row loot-row";
       (playerData.bonuses.loot || []).forEach(partnerIndex => {
         const container = document.createElement("div");
         container.className = "bonus-counter";

--- a/style.css
+++ b/style.css
@@ -15,6 +15,10 @@
   grid-column: 1 / -1;
 }
 
+.bonus-row.loot-row {
+  justify-content: flex-start;
+}
+
 .bonus-counter {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Align loot pairings to start by giving loot rows their own flex-start alignment
- Mark loot pairing container with `loot-row` class for targeted styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689914dd73e4832bbd47ce40259607f9