### PR TITLE
Fix scoring to use modified bid value

### DIFF
--- a/app.js
+++ b/app.js
@@ -526,10 +526,10 @@ function computeScore(player, roundIndex) {
   const modifiedBid = bid + bidMod;
   const made = actual === modifiedBid;
   let base = 0;
-  if (bid === 0)
+  if (modifiedBid === 0)
     base = (made ? 1 : -1) * (roundIndex + 1) * 10;
   else
-    base = made ? 20 * bid : -10 * Math.abs(actual - modifiedBid);
+    base = made ? 20 * modifiedBid : -10 * Math.abs(actual - modifiedBid);
   let loot = 0;
   // Filter out any loot partnerships that reference players that no longer exist
   const roundPlayers = gameState.rounds[roundIndex]?.players || [];


### PR DESCRIPTION
## Summary
- ensure scoring treats the pirate bid modifier as part of the player's bid when calculating base points

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cca00a36a0832bb034b80303051325